### PR TITLE
Non-mosaic XEM transfers pay 1 XEM per 10,000 XEM, not 1,000 XEM

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ var getFee = function(amount, messageType, message) {
   }else if(amount > 250000) {
     fee += 25;
   }else {
-    fee += Math.floor(amount / 1000);
+    fee += Math.floor(amount / 10000);
   }
 
   // message fee


### PR DESCRIPTION
According to [forum](https://forum.nem.io/t/nem-update-0-6-82-lower-fees-and-new-api/2979), Non-mosaic XEM transfers pay 1 XEM per 10,000 XEM ,not 1000XEM.